### PR TITLE
Skip Popup

### DIFF
--- a/index.php
+++ b/index.php
@@ -68,42 +68,47 @@ if (!empty($myconfig->startwithdb)) {
     $urloptions['db'] = $CFG->dbname;
 }
 $adminerurl = new \moodle_url('/local/adminer/lib/run_adminer.php', $urloptions);
-$framebackgroundurl = new \moodle_url('/pix/y/loading.gif');
 
-$modalcss = '
-    .modal-dialog {
-        max-width: 80%;
-        margin-top: 5px;
-        margin-bottom: 0;
-    }
-    .modal-content {
-        max-height: 99vh;
-    }
-    #adminer-frame {
-        background:url('.$framebackgroundurl->out().') center center no-repeat;
-    }
 
-    {{#legacycss}}
-        .modal-backdrop.show {
-            opacity: 0.8;
-        }
-        #local-adminer-modal.modal.fade.show {
-            opacity: 1;
-        }
-    {{/legacycss}}
-';
+// Execution ends here.
+redirect($adminerurl);
 
-$content = new \stdClass();
-$content->adminerurl = $adminerurl->out(false);
-$content->adminerlaunchtitle = get_string('launchadminer', 'local_adminer');
-// $content->framebackgroundurl = new \moodle_url('/pix/y/loading.gif');
-$content->title = get_string('pluginname', 'local_adminer');
-$content->modalcss = $modalcss;
-if ($legacycss) {
-    $content->legacycss = new \moodle_url('/local/adminer/legacy/legacy.css');
-}
-
-echo $OUTPUT->header();
-echo $OUTPUT->heading(get_string('pluginname', 'local_adminer'));
-echo $OUTPUT->render_from_template('local_adminer/adminer', $content);
-echo $OUTPUT->footer();
+//$framebackgroundurl = new \moodle_url('/pix/y/loading.gif');
+//
+//$modalcss = '
+//    .modal-dialog {
+//        max-width: 80%;
+//        margin-top: 5px;
+//        margin-bottom: 0;
+//    }
+//    .modal-content {
+//        max-height: 99vh;
+//    }
+//    #adminer-frame {
+//        background:url('.$framebackgroundurl->out().') center center no-repeat;
+//    }
+//
+//    {{#legacycss}}
+//        .modal-backdrop.show {
+//            opacity: 0.8;
+//        }
+//        #local-adminer-modal.modal.fade.show {
+//            opacity: 1;
+//        }
+//    {{/legacycss}}
+//';
+//
+//$content = new \stdClass();
+//$content->adminerurl = $adminerurl->out(false);
+//$content->adminerlaunchtitle = get_string('launchadminer', 'local_adminer');
+//// $content->framebackgroundurl = new \moodle_url('/pix/y/loading.gif');
+//$content->title = get_string('pluginname', 'local_adminer');
+//$content->modalcss = $modalcss;
+//if ($legacycss) {
+//    $content->legacycss = new \moodle_url('/local/adminer/legacy/legacy.css');
+//}
+//
+//echo $OUTPUT->header();
+//echo $OUTPUT->heading(get_string('pluginname', 'local_adminer'));
+//echo $OUTPUT->render_from_template('local_adminer/adminer', $content);
+//echo $OUTPUT->footer();


### PR DESCRIPTION
Immediately redirect to Adminer page to skip popup.
This both skips the popup which is broken in Moodle 4.1 with the RemUI theme and is better for how we use it.